### PR TITLE
Forces 0 Paint Seed when null

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -182,6 +182,9 @@ class Bot extends EventEmitter {
                 itemData.iteminfo.d = this.currentRequest.d;
                 itemData.iteminfo.m = this.currentRequest.m;
 
+                // If the paintseed is 0, the proto returns null, force 0
+                itemData.iteminfo.paintseed = itemData.iteminfo.paintseed || 0;
+
                 this.resolve(itemData);
                 this.resolve = false;
                 this.currentRequest = false;


### PR DESCRIPTION
Fixes #9 

The proto returns null in cases where the paintseed is 0, this PR forces it.