### PR TITLE
Separates Regex and Non-Regex Origin Whitelist

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -42,14 +42,17 @@ module.exports = {
         // Amount of milliseconds to wait until a request to Valve is timed out
         "request_ttl": 2000
     },
-    // Origins allowed to connect to the HTTP/HTTPS API (supports regex)
+    // Origins allowed to connect to the HTTP/HTTPS API
     "allowed_origins": [
         "http://example.com",
         "https://example.com",
         "chrome-extension://jjicbefpemnphinccgikpdaagjebbnhg",
         "http://steamcommunity.com",
-        "https://steamcommunity.com",
-        "https://*.steamcommunity.com"
+        "https://steamcommunity.com"
+    ],
+    // Origins allowed to connect to the HTTP/HTTPS API with Regex
+    "allowed_regex_origins": [
+        "https://.*\\.steamcommunity\\.com"
     ],
     // Logging Level (error, warn, info, verbose, debug, silly)
     "logLevel": "debug",

--- a/index.js
+++ b/index.js
@@ -75,15 +75,18 @@ const lookupHandler = function (params) {
 // Setup and configure express
 let app = require('express')();
 
-const allowedRegexOrigins = CONFIG.allowed_origins.map((origin) => new RegExp(origin));
+CONFIG.allowed_regex_origins = CONFIG.allowed_regex_origins || [];
+CONFIG.allowed_origins = CONFIG.allowed_origins || [];
+const allowedRegexOrigins = CONFIG.allowed_regex_origins.map((origin) => new RegExp(origin));
 
 app.get('/', function(req, res) {
     // Allow some origins
     if (CONFIG.allowed_origins.length > 0 && req.get('origin') != undefined) {
         // check to see if its a valid domain
-        const allowed = allowedRegexOrigins.findIndex((reg) => reg.test(req.get('origin')));
+        const allowed = CONFIG.allowed_origins.indexOf(req.get('origin')) > -1 ||
+            allowedRegexOrigins.findIndex((reg) => reg.test(req.get('origin'))) > -1;
 
-        if (allowed > -1) {
+        if (allowed) {
             res.header('Access-Control-Allow-Origin', req.get('origin'));
             res.header('Access-Control-Allow-Methods', 'GET');
         }


### PR DESCRIPTION
#14 was not backwards compatible due to using the pre-existing equality match array. This PR separates the fields.