### PR TITLE
Schema url now gets a certain branch instead of master branch

### DIFF
--- a/lib/game_data.js
+++ b/lib/game_data.js
@@ -35,7 +35,7 @@ class GameData {
         this.items_game_url = 'https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/csgo/scripts/items/items_game.txt';
         this.items_game_cdn_url = 'https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/csgo/scripts/items/items_game_cdn.txt';
         this.csgo_english_url = 'https://raw.githubusercontent.com/SteamDatabase/GameTracking-CSGO/master/csgo/resource/csgo_english.txt';
-        this.schema_url = 'https://raw.githubusercontent.com/SteamDatabase/SteamTracking/master/ItemSchema/CounterStrikeGlobalOffensive.json';
+        this.schema_url = 'https://raw.githubusercontent.com/SteamDatabase/SteamTracking/b5cba7a22ab899d6d423380cff21cec707b7c947/ItemSchema/CounterStrikeGlobalOffensive.json';
 
         this.items_game = false;
         this.items_game_cdn = false;


### PR DESCRIPTION
The old schema url returns 404. This pull request instead gets the most recent version of the older version.

This way the code is executable again without errors